### PR TITLE
Fix broken storybook entries

### DIFF
--- a/frontend/src/stories/components/Nav/AppNavbar.stories.js
+++ b/frontend/src/stories/components/Nav/AppNavbar.stories.js
@@ -2,6 +2,8 @@
 import React from 'react';
 
 import AppNavbar from "main/components/Nav/AppNavbar";
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { systemInfoFixtures } from 'fixtures/systemInfoFixtures';
 
 export default {
     title: 'components/Nav/AppNavbar',
@@ -15,27 +17,61 @@ const Template = (args) => {
     )
 };
 
-export const noRole = Template.bind({});
+export const basic_notLoggedIn = Template.bind({});
 
-export const admin = Template.bind({});
-admin.args = {
-    role: "admin"
+
+export const basic_loggedInAdminUser = Template.bind({});
+basic_loggedInAdminUser.args = {
+    currentUser: currentUserFixtures.adminUser
 };
 
-export const localhost3000 = Template.bind({});
-localhost3000.args = {
+export const basic_loggedInRegularUser = Template.bind({});
+basic_loggedInRegularUser.args = {
+    currentUser: currentUserFixtures.userOnly
+};
+
+export const extraLinks_neitherH2NorSwagger = Template.bind({});
+extraLinks_neitherH2NorSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingNeither
+}
+
+export const extraLinks_H2Only = Template.bind({});
+extraLinks_H2Only.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": true,
+        "showSwaggerUILink": false,
+    }
+};
+
+export const extraLinks_SwaggerOnly = Template.bind({});
+extraLinks_SwaggerOnly.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: {
+        "springH2ConsoleEnabled": false,
+        "showSwaggerUILink": true,
+    }
+};
+
+export const extraLinks_bothH2AndSwagger = Template.bind({});
+extraLinks_bothH2AndSwagger.args = {
+    currentUser: currentUserFixtures.userOnly,
+    systemInfo: systemInfoFixtures.showingAll
+};
+
+
+export const localhost_3000 = Template.bind({});
+localhost_3000.args = {
     currentUrl: "http://localhost:3000"
 };
 
-export const localhostNumeric3000 = Template.bind({});
-localhostNumeric3000.args = {
+export const localhost_127_0_0_1__3000 = Template.bind({});
+localhost_127_0_0_1__3000.args = {
     currentUrl: "http://127.0.0.1:3000"
 };
 
-export const localhost8080 = Template.bind({});
-localhost8080.args = {
+export const localhost_8080 = Template.bind({});
+localhost_8080.args = {
     currentUrl: "http://localhost:8080"
 };
-
-
-

--- a/frontend/src/stories/components/Profile/RoleBadge.stories.js
+++ b/frontend/src/stories/components/Profile/RoleBadge.stories.js
@@ -1,6 +1,6 @@
 
 import React from 'react';
-
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import RoleBadge from "main/components/Profile/RoleBadge";
 
 export default {
@@ -8,19 +8,20 @@ export default {
     component: RoleBadge
 };
 
-
 const Template = (args) => {
     return (
         <RoleBadge {...args} />
     )
 };
 
-export const noRole = Template.bind({});
+export const user = Template.bind({});
+user.args = {
+    role: "ROLE_USER",
+    currentUser: currentUserFixtures.userOnly
+};
 
 export const admin = Template.bind({});
 admin.args = {
-    role: "admin"
+    role: "ROLE_ADMIN",
+    currentUser: currentUserFixtures.adminUser
 };
-
-
-


### PR DESCRIPTION
This is a PR to fix a bug discoverd by @Aasish-Virjala where the storybook entries for `RoleBadge' were broken and viewing those storybook entries would break everything else.

Previously broken:
![image](https://github.com/ucsb-cs156-s24/STARTER-jpa03/assets/56096744/301b3d75-669a-4f02-b0ec-e617d12def89)
![image](https://github.com/ucsb-cs156-s24/STARTER-jpa03/assets/56096744/8da6331f-3781-4a71-b2af-8070333691f4)

Screenshots of currently working storybook:
![Screenshot 2024-04-11 110029](https://github.com/ucsb-cs156-s24/STARTER-jpa03/assets/56096744/853706a1-c745-4777-b723-a3834dabfb8e)
![Screenshot 2024-04-11 110033](https://github.com/ucsb-cs156-s24/STARTER-jpa03/assets/56096744/2b07045d-2863-4b72-be34-b7c4c4997e23)
![Screenshot 2024-04-11 110037](https://github.com/ucsb-cs156-s24/STARTER-jpa03/assets/56096744/f93f36db-a15f-4899-bd0d-10541cba2d46)
